### PR TITLE
Promise api example

### DIFF
--- a/cordova-plugin-mobile-center-analytics/www/Analytics.js
+++ b/cordova-plugin-mobile-center-analytics/www/Analytics.js
@@ -1,26 +1,17 @@
 var exec = require('cordova/exec');
 
 module.exports = {
-    trackEvent: function(eventName, properties, success, error) {
-        exec(success, error, "MobileCenterAnalytics", "trackEvent",
-            [eventName, sanitizeProperties(properties)]);
-    },
+    trackEvent: (eventName, properties) =>
+        Promise((resolve, reject) =>
+            exec(resolve, reject,
+                "MobileCenterAnalytics", "trackEvent",
+                [eventName, sanitizeProperties(properties)])),
 
-    isEnabled: function(success, error) {
-        exec(success, error, "MobileCenterAnalytics", "isEnabled");
-    },
+    isEnabled: () => Promise((resolve, reject) =>
+        exec(resolve, reject, "MobileCenterAnalytics", "isEnabled")),
 
-    setEnabled: function(enabled, success, error) {
-        exec(success, error, "MobileCenterAnalytics", "setEnabled", [enabled]);
-    },
-
-    /*
-    // TODO: Uncomment this once the underlying SDK supports the functionality
-    trackPage: function(pageName, properties, success, error) {
-        exec(success, error, "MobileCenterAnalytics", "trackPage",
-            [pageName, sanitizeProperties(properties)]);
-    }
-    */
+    setEnabled: (enabled) => Promise((resolve, reject) =>
+        exec(resolve, reject, "MobileCenterAnalytics", "setEnabled", [enabled])),
 };
 
 function sanitizeProperties(props) {

--- a/cordova-plugin-mobile-center-analytics/www/Analytics.js
+++ b/cordova-plugin-mobile-center-analytics/www/Analytics.js
@@ -2,15 +2,15 @@ var exec = require('cordova/exec');
 
 module.exports = {
     trackEvent: (eventName, properties) =>
-        Promise((resolve, reject) =>
+        new Promise((resolve, reject) =>
             exec(resolve, reject,
                 "MobileCenterAnalytics", "trackEvent",
                 [eventName, sanitizeProperties(properties)])),
 
-    isEnabled: () => Promise((resolve, reject) =>
+    isEnabled: () => new Promise((resolve, reject) =>
         exec(resolve, reject, "MobileCenterAnalytics", "isEnabled")),
 
-    setEnabled: (enabled) => Promise((resolve, reject) =>
+    setEnabled: (enabled) => new Promise((resolve, reject) =>
         exec(resolve, reject, "MobileCenterAnalytics", "setEnabled", [enabled])),
 };
 


### PR DESCRIPTION
This is an example of reimplementing JS API in Promise-based manner. According to https://caniuse.com/#feat=promises Promises are supported in Android >= 5 and iOS >= 8, so promise-based API might be a better choice if support of older Android and iOS versions is not a concern.