### PR TITLE
[Android ]Change com.microsoft.azure.mobile.* to com.microsoft.appcenter.*

### DIFF
--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -41,7 +41,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.azure.mobile:appcenter-analytics:0.12.0" />
+        <framework src="com.microsoft.appcenter:appcenter-analytics:1.1.0" />
 
         <source-file src="src/android/AppCenterAnalyticsPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />

--- a/cordova-plugin-appcenter-analytics/src/android/AppCenterAnalyticsPlugin.java
+++ b/cordova-plugin-appcenter-analytics/src/android/AppCenterAnalyticsPlugin.java
@@ -10,8 +10,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.microsoft.azure.mobile.AppCenter;
-import com.microsoft.azure.mobile.analytics.Analytics;
+import com.microsoft.appcenter.AppCenter;
+import com.microsoft.appcenter.analytics.Analytics;
 
 public class AppCenterAnalyticsPlugin extends CordovaPlugin {
     private static final String ENABLE_IN_JS = "APPCENTER_ANALYTICS_ENABLE_IN_JS";

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -42,7 +42,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.azure.mobile:appcenter-crashes:0.12.0" />
+        <framework src="com.microsoft.appcenter:appcenter-crashes:1.1.0" />
 
         <source-file src="src/android/AppCenterCrashesPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />

--- a/cordova-plugin-appcenter-crashes/src/android/AppCenterCrashesPlugin.java
+++ b/cordova-plugin-appcenter-crashes/src/android/AppCenterCrashesPlugin.java
@@ -10,10 +10,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.microsoft.azure.mobile.AppCenter;
-import com.microsoft.azure.mobile.crashes.Crashes;
-import com.microsoft.azure.mobile.crashes.model.ErrorReport;
-import com.microsoft.azure.mobile.utils.async.AppCenterConsumer;
+import com.microsoft.appcenter.AppCenter;
+import com.microsoft.appcenter.crashes.Crashes;
+import com.microsoft.appcenter.crashes.model.ErrorReport;
+import com.microsoft.appcenter.utils.async.AppCenterConsumer;
 
 import java.util.List;
 

--- a/cordova-plugin-appcenter-crashes/src/android/CordovaCrashListener.java
+++ b/cordova-plugin-appcenter-crashes/src/android/CordovaCrashListener.java
@@ -1,11 +1,10 @@
 package com.microsoft.azure.mobile.cordova;
 
-import com.microsoft.azure.mobile.crashes.AbstractCrashesListener;
-
 import android.util.Base64;
 
-import com.microsoft.azure.mobile.crashes.ingestion.models.ErrorAttachmentLog;
-import com.microsoft.azure.mobile.crashes.model.ErrorReport;
+import com.microsoft.appcenter.crashes.AbstractCrashesListener;
+import com.microsoft.appcenter.crashes.ingestion.models.ErrorAttachmentLog;
+import com.microsoft.appcenter.crashes.model.ErrorReport;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.LOG;

--- a/cordova-plugin-appcenter-crashes/src/android/CrashesUtils.java
+++ b/cordova-plugin-appcenter-crashes/src/android/CrashesUtils.java
@@ -2,8 +2,8 @@ package com.microsoft.azure.mobile.cordova;
 
 import android.util.Log;
 
-import com.microsoft.azure.mobile.crashes.model.ErrorReport;
-import com.microsoft.azure.mobile.ingestion.models.Device;
+import com.microsoft.appcenter.crashes.model.ErrorReport;
+import com.microsoft.appcenter.ingestion.models.Device;
 
 import org.apache.cordova.LOG;
 import org.json.JSONArray;

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -42,7 +42,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.azure.mobile:appcenter-push:0.12.0" />
+        <framework src="com.microsoft.appcenter:appcenter-push:1.1.0" />
         <framework src="src/android/AppCenterPush.gradle"
                    custom="true" type="gradleReference" />
 

--- a/cordova-plugin-appcenter-push/src/android/AppCenterPushPlugin.java
+++ b/cordova-plugin-appcenter-push/src/android/AppCenterPushPlugin.java
@@ -8,8 +8,8 @@ import org.apache.cordova.CordovaWebView;
 import org.json.JSONArray;
 import org.json.JSONException;
 
-import com.microsoft.azure.mobile.AppCenter;
-import com.microsoft.azure.mobile.push.Push;
+import com.microsoft.appcenter.AppCenter;
+import com.microsoft.appcenter.push.Push;
 
 public class AppCenterPushPlugin extends CordovaPlugin {
     private CordovaPushListener listener;

--- a/cordova-plugin-appcenter-push/src/android/CordovaPushListener.java
+++ b/cordova-plugin-appcenter-push/src/android/CordovaPushListener.java
@@ -3,8 +3,8 @@ package com.microsoft.azure.mobile.cordova;
 import android.app.Activity;
 import android.util.Log;
 
-import com.microsoft.azure.mobile.push.PushListener;
-import com.microsoft.azure.mobile.push.PushNotification;
+import com.microsoft.appcenter.push.PushListener;
+import com.microsoft.appcenter.push.PushNotification;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.LOG;

--- a/cordova-plugin-appcenter-push/src/android/PushUtils.java
+++ b/cordova-plugin-appcenter-push/src/android/PushUtils.java
@@ -1,6 +1,6 @@
 package com.microsoft.azure.mobile.cordova;
 
-import com.microsoft.azure.mobile.push.PushNotification;
+import com.microsoft.appcenter.push.PushNotification;
 
 import java.util.Iterator;
 import java.util.Map;

--- a/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
+++ b/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
@@ -4,8 +4,8 @@ import android.app.Application;
 
 import org.apache.cordova.CordovaPreferences;
 
-import com.microsoft.azure.mobile.AppCenter;
-import com.microsoft.azure.mobile.ingestion.models.WrapperSdk;
+import com.microsoft.appcenter.AppCenter;
+import com.microsoft.appcenter.ingestion.models.WrapperSdk;
 
 class AppCenterShared {
 

--- a/cordova-plugin-appcenter-shared/src/android/AppCenterUtils.java
+++ b/cordova-plugin-appcenter-shared/src/android/AppCenterUtils.java
@@ -1,7 +1,7 @@
 package com.microsoft.azure.mobile.cordova;
 
-import com.microsoft.azure.mobile.utils.async.AppCenterConsumer;
-import com.microsoft.azure.mobile.utils.async.AppCenterFuture;
+import com.microsoft.appcenter.utils.async.AppCenterConsumer;
+import com.microsoft.appcenter.utils.async.AppCenterFuture;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;


### PR DESCRIPTION
On android all plugins was using `com.microsoft.azure.mobile` namespace for maven dependencies, but it was transferred to `com.microsoft.appcenter` so all related stuff need to be changed too. This PR fix namespace prefixes for all android deps.

https://bintray.com/vsappcenter/appcenter/appcenter-analytics
https://bintray.com/vsappcenter/appcenter/appcenter-push
https://bintray.com/vsappcenter/appcenter/appcenter-crashes

After that changes sample app builds successfully.