### PR TITLE
[iOS][Analytics] Fix incorrect eventName parameter parse

### DIFF
--- a/cordova-plugin-appcenter-analytics/src/ios/AppCenterAnalyticsPlugin.m
+++ b/cordova-plugin-appcenter-analytics/src/ios/AppCenterAnalyticsPlugin.m
@@ -49,7 +49,7 @@
 
 - (void)trackEvent:(CDVInvokedUrlCommand *)command
 {
-    NSString* eventName = [[command argumentAtIndex:0] stringValue];
+    NSString* eventName = [command argumentAtIndex:0 withDefault:nil andClass:[NSString class]];
     NSDictionary* properties = [command argumentAtIndex:1];
 
     [MSAnalytics trackEvent:eventName withProperties:properties];


### PR DESCRIPTION
This PR fixes this [bug](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/30431).