### PR TITLE
Fix example project

### DIFF
--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -20,7 +20,7 @@
     <engine name="cordova-ios" version=">=4.3.0" />
 
     <dependency id="cordova-plugin-appcenter-shared"
-                subdir="cordova-plugin-appcenter-shared"
+                subdir="../cordova-plugin-appcenter-shared"
                 url="." />
 
     <js-module name="Analytics" src="www/Analytics.js">

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -21,7 +21,7 @@
     <engine name="cordova-ios" version=">=4.3.0" />
 
     <dependency id="cordova-plugin-appcenter-shared"
-                subdir="cordova-plugin-appcenter-shared"
+                subdir="../cordova-plugin-appcenter-shared"
                 url="." />
 
     <js-module name="Crashes" src="www/Crashes.js">

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -21,7 +21,7 @@
     <engine name="cordova-ios" version=">=4.3.0" />
 
     <dependency id="cordova-plugin-appcenter-shared"
-                subdir="cordova-plugin-appcenter-shared"
+                subdir="../cordova-plugin-appcenter-shared"
                 url="." />
 
     <js-module name="Push" src="www/Push.js">


### PR DESCRIPTION
Dependency for appcenter plugins not loaded locally because of the wrong path to local dir. This caused infinite installation loop.