### PR TITLE
[Android][Push] fix SENDER_ID type issue

### DIFF
--- a/cordova-plugin-appcenter-push/src/android/AppCenterPushPlugin.java
+++ b/cordova-plugin-appcenter-push/src/android/AppCenterPushPlugin.java
@@ -23,6 +23,9 @@ public class AppCenterPushPlugin extends CordovaPlugin {
                 cordova.getActivity().getApplication(),
                 webView.getPreferences());
 
+        // For some reason Cordova reads SENDER_ID preference as double. 
+        // Because of this Pushes does not work properly, 
+        // as workaround SENDER_ID value should be wrapped by single quotes.
         String senderId = webView.getPreferences().getString(SENDER_ID, null).replace("'", "");
         Push.setSenderId(senderId);
 

--- a/cordova-plugin-appcenter-push/src/android/AppCenterPushPlugin.java
+++ b/cordova-plugin-appcenter-push/src/android/AppCenterPushPlugin.java
@@ -23,7 +23,7 @@ public class AppCenterPushPlugin extends CordovaPlugin {
                 cordova.getActivity().getApplication(),
                 webView.getPreferences());
 
-        String senderId = webView.getPreferences().getString(SENDER_ID, null);
+        String senderId = webView.getPreferences().getString(SENDER_ID, null).replace("'", "");
         Push.setSenderId(senderId);
 
         listener = new CordovaPushListener();

--- a/sample/config.xml
+++ b/sample/config.xml
@@ -23,7 +23,8 @@
 
     <platform name="android">
         <preference name="APP_SECRET" value="your_android_application_id" />
-        <preference name="FIREBASE_SENDER_ID" value="your_firebase_sender_id" />
+        <!-- Do not replace single quotes from the value below -->
+        <preference name="FIREBASE_SENDER_ID" value="'your_firebase_sender_id'" />
         <allow-intent href="market:*" />
     </platform>
 


### PR DESCRIPTION
For some reason Cordova reads SENDER_ID preference as double. Because of this Pushes does not work properly, as workaround SENDER_ID value should be wrapped by single quotes.