### PR TITLE
Fixes issue #27

### DIFF
--- a/cordova-plugin-appcenter-analytics/www/Analytics.js
+++ b/cordova-plugin-appcenter-analytics/www/Analytics.js
@@ -7,7 +7,7 @@ module.exports = {
     },
 
     isEnabled: function(success, error) {
-        exec(success, error, "AppCenterAnalytics", "isEnabled");
+        exec(success, error, "AppCenterAnalytics", "isEnabled", []);
     },
 
     setEnabled: function(enabled, success, error) {

--- a/cordova-plugin-appcenter-crashes/www/Crashes.js
+++ b/cordova-plugin-appcenter-crashes/www/Crashes.js
@@ -9,19 +9,19 @@ var channels = {
 
 var Crashes = {
     generateTestCrash: function (error) {
-        exec(null, error, "AppCenterCrashes", "generateTestCrash");
+        exec(null, error, "AppCenterCrashes", "generateTestCrash", []);
     },
 
     hasCrashedInLastSession: function (success, error) {
-        exec(success, error, "AppCenterCrashes", "hasCrashedInLastSession");
+        exec(success, error, "AppCenterCrashes", "hasCrashedInLastSession", []);
     },
 
     lastSessionCrashReport: function (success, error) {
-        exec(success, error, "AppCenterCrashes", "lastSessionCrashReport");
+        exec(success, error, "AppCenterCrashes", "lastSessionCrashReport", []);
     },
 
     isEnabled: function (success, error) {
-        exec(success, error, "AppCenterCrashes", "isEnabled");
+        exec(success, error, "AppCenterCrashes", "isEnabled", []);
     },
 
     setEnabled: function (shouldEnable, success, error) {
@@ -81,7 +81,7 @@ var Crashes = {
             });
         }
 
-        exec(processReports, failIfNotEnabled, "AppCenterCrashes", "getCrashReports");
+        exec(processReports, failIfNotEnabled, "AppCenterCrashes", "getCrashReports", []);
     },
 
     addEventListener: function (eventname, f) {

--- a/cordova-plugin-appcenter-push/www/Push.js
+++ b/cordova-plugin-appcenter-push/www/Push.js
@@ -7,7 +7,7 @@ var channels = {
 
 var Push = {
     isEnabled: function (success, error) {
-        exec(success, error, "AppCenterPush", "isEnabled");
+        exec(success, error, "AppCenterPush", "isEnabled", []);
     },
 
     setEnabled: function (shouldEnable, success, error) {
@@ -17,7 +17,7 @@ var Push = {
     addEventListener: function (eventname, f) {
         if (eventname in channels) {
             channels[eventname].subscribe(f);
-            exec(null, null, "AppCenterPush", "sendAndClearInitialNotification");
+            exec(null, null, "AppCenterPush", "sendAndClearInitialNotification", []);
         }
     },
 


### PR DESCRIPTION
Fixes issue #27. The problem is that cordova-android platforms prior to 6.0 don't have a [check](https://github.com/apache/cordova-android/blob/6.0.x/cordova-js-src/exec.js#L82) for null args parameter for exec method. 