### PR TITLE
Fix crash on start with push module

### DIFF
--- a/cordova-plugin-appcenter-push/src/android/AppCenterPushPlugin.java
+++ b/cordova-plugin-appcenter-push/src/android/AppCenterPushPlugin.java
@@ -26,7 +26,7 @@ public class AppCenterPushPlugin extends CordovaPlugin {
         // For some reason Cordova reads SENDER_ID preference as double. 
         // Because of this Pushes does not work properly, 
         // as workaround SENDER_ID value should be wrapped by single quotes.
-        String senderId = webView.getPreferences().getString(SENDER_ID, null).replace("'", "");
+        String senderId = webView.getPreferences().getString(SENDER_ID, "").replace("'", "");
         Push.setSenderId(senderId);
 
         listener = new CordovaPushListener();


### PR DESCRIPTION
If FIREBASE_SENDER_ID is not set in preferences app will crash on startup. We need to return an empty string if FIREBASE_SENDER_ID is not set.
Fixes #29 