### PR TITLE
Send crashes by default

### DIFF
--- a/cordova-plugin-appcenter-crashes/src/android/AppCenterCrashesPlugin.java
+++ b/cordova-plugin-appcenter-crashes/src/android/AppCenterCrashesPlugin.java
@@ -25,7 +25,7 @@ public class AppCenterCrashesPlugin extends CordovaPlugin {
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
 
-        boolean sendAutomatically = webView.getPreferences().getBoolean(ALWAYS_SEND, false);
+        boolean sendAutomatically = webView.getPreferences().getBoolean(ALWAYS_SEND, true);
         crashListener = sendAutomatically ?
                 new CordovaCrashesListenerAlwaysSend():
                 new CordovaCrashesListenerAlwaysAsk();

--- a/cordova-plugin-appcenter-crashes/src/ios/AppCenterCrashesPlugin.m
+++ b/cordova-plugin-appcenter-crashes/src/ios/AppCenterCrashesPlugin.m
@@ -17,7 +17,7 @@ static BOOL crashProcessingDelayFinished = NO;
 {
     BOOL sendAutomatically = [self.commandDelegate.settings
                               cordovaBoolSettingForKey:@"APPCENTER_CRASHES_ALWAYS_SEND"
-                              defaultValue:NO];
+                              defaultValue:YES];
 
     [AppCenterShared configureWithSettings:self.commandDelegate.settings];
 


### PR DESCRIPTION
To harmonize with [docs](https://docs.microsoft.com/en-us/appcenter/sdk/getting-started/cordova#analytics-preferences) we should send crashes by default