### PR TITLE
Configure logUrl from preferences

### DIFF
--- a/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
+++ b/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
@@ -11,6 +11,7 @@ class AppCenterShared {
     private final static String VERSION_NAME = "0.0.1";
     private final static String SDK_NAME = "appcenter.cordova";
     private static final String APP_SECRET = "APP_SECRET";
+    private static final String LOG_URL = "LOG_URL";
     private static String appSecret;
     private static final WrapperSdk wrapperSdk = new WrapperSdk();
 
@@ -24,6 +25,11 @@ class AppCenterShared {
 
         AppCenter.setWrapperSdk(wrapperSdk);
         AppCenter.configure(application, AppCenterShared.getAppSecret(preferences));
+
+        final String logUrl = preferences.getString(LOG_URL, null);
+        if (logUrl != null && !logUrl.isEmpty()) {
+            AppCenter.setLogUrl(logUrl);
+        }
     }
 
     private static String getAppSecret(CordovaPreferences preferences) {

--- a/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
+++ b/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
@@ -4,6 +4,7 @@
 @implementation AppCenterShared
 
 static NSString *appSecret;
+static NSString *logUrl;
 static MSWrapperSdk * wrapperSdk;
 
 + (void) setAppSecret: (NSString *)secret
@@ -44,6 +45,11 @@ static MSWrapperSdk * wrapperSdk;
 
     [self setWrapperSdk:wrapperSdk];
     [MSAppCenter configureWithAppSecret:[AppCenterShared getAppSecretWithSettings: settings]];
+
+    logUrl = [settings cordovaSettingForKey:@"LOG_URL"];
+    if (logUrl != nil) {
+        [MSAppCenter setLogUrl:logUrl];
+    }
 }
 
 + (MSWrapperSdk *) getWrapperSdk


### PR DESCRIPTION
Setting custom logUrl from preferences:

Example
`<preference name="LOG_URL" value="https://custom-ingestion.endpoint.com" />`