### PR TITLE
Update cordova-ios version in demoapp

### DIFF
--- a/demoapp/config.xml
+++ b/demoapp/config.xml
@@ -37,5 +37,5 @@
     <plugin name="cordova-plugin-appcenter-push" spec="^0.3.3" />
     <plugin name="cordova-plugin-appcenter-shared" spec="^0.3.3" />
     <engine name="android" spec="^7.0.0" />
-    <engine name="ios" spec="~4.5.4" />
+    <engine name="ios" spec="^5.0.0" />
 </widget>

--- a/demoapp/config.xml
+++ b/demoapp/config.xml
@@ -37,5 +37,5 @@
     <plugin name="cordova-plugin-appcenter-push" spec="^0.3.3" />
     <plugin name="cordova-plugin-appcenter-shared" spec="^0.3.3" />
     <engine name="android" spec="^7.0.0" />
-    <engine name="ios" spec="^5.0.0" />
+    <engine name="ios" spec="5.0.0" />
 </widget>

--- a/demoapp/package.json
+++ b/demoapp/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cordova-android": "^7.0.0",
-    "cordova-ios": "^4.5.4",
+    "cordova-ios": "^5.0.0",
     "cordova-plugin-appcenter-analytics": "^0.3.3",
     "cordova-plugin-appcenter-crashes": "^0.3.3",
     "cordova-plugin-appcenter-push": "^0.3.3",

--- a/demoapp/package.json
+++ b/demoapp/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cordova-android": "^7.0.0",
-    "cordova-ios": "^5.0.0",
+    "cordova-ios": "5.0.0",
     "cordova-plugin-appcenter-analytics": "^0.3.3",
     "cordova-plugin-appcenter-crashes": "^0.3.3",
     "cordova-plugin-appcenter-push": "^0.3.3",


### PR DESCRIPTION
cordova-ios 5.0.0 has been released recently which fixes all the dropping iOS 8 support errors.