### PR TITLE
Replace deprecated framework tag

### DIFF
--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -60,6 +60,14 @@
         <header-file src="src/ios/AppCenterAnalyticsPlugin.h" />
         <source-file src="src/ios/AppCenterAnalyticsPlugin.m" />
 
+        <podspec>
+            <config>
+                <source url="https://github.com/CocoaPods/Specs.git"/>
+            </config>
+            <pods use-frameworks="true">
+                <pod name="AppCenter/Analytics" spec="~> 2.1.0" />
+            </pods>
+        </podspec>
         <framework src="AppCenter" type="podspec" spec="~> 2.1.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -69,6 +69,15 @@
         <header-file src="src/ios/CrashesUtils.h" />
         <source-file src="src/ios/CrashesUtils.m" />
 
+        <podspec>
+            <config>
+                <source url="https://github.com/CocoaPods/Specs.git"/>
+            </config>
+            <pods use-frameworks="true">
+                <pod name="AppCenter/Crashes" spec="~> 2.1.0" />
+            </pods>
+        </podspec>
+
         <framework src="AppCenter" type="podspec" spec="~> 2.1.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -85,6 +85,15 @@
         <header-file src="src/ios/PushUtils.h" />
         <source-file src="src/ios/PushUtils.m" />
 
+        <podspec>
+            <config>
+                <source url="https://github.com/CocoaPods/Specs.git"/>
+            </config>
+            <pods use-frameworks="true">
+                <pod name="AppCenter/Push" spec="~> 2.1.0" />
+            </pods>
+        </podspec>
+
         <framework src="AppCenter/Push" type="podspec" spec="~> 2.1.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-shared/plugin.xml
+++ b/cordova-plugin-appcenter-shared/plugin.xml
@@ -1,8 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
+<<<<<<< Updated upstream
 <plugin id="cordova-plugin-appcenter-shared"
         version="0.3.5"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
+=======
+<plugin id="cordova-plugin-appcenter-shared" version="0.3.4" 
+    xmlns="http://apache.org/cordova/ns/plugins/1.0" 
+    xmlns:android="http://schemas.android.com/apk/res/android">
+>>>>>>> Stashed changes
 
     <name>App Center shared code for Cordova</name>
     <description>
@@ -18,26 +24,22 @@
     <!-- Cordova 6.4.0 and iOS 4.3.0 are required for Cocoapods support -->
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
-    
+
     <js-module name="AppCenter" src="www/AppCenter.js">
         <clobbers target="AppCenter" />
     </js-module>
 
     <platform name="android">
-        <source-file src="src/android/AppCenterShared.java"
-                     target-dir="src/com/microsoft/azure/mobile/cordova" />
+        <source-file src="src/android/AppCenterShared.java" target-dir="src/com/microsoft/azure/mobile/cordova" />
 
-        <source-file src="src/android/AppCenterUtils.java"
-                     target-dir="src/com/microsoft/azure/mobile/cordova" />
+        <source-file src="src/android/AppCenterUtils.java" target-dir="src/com/microsoft/azure/mobile/cordova" />
 
-        <source-file src="src/android/AppCenterSharedPlugin.java"
-                target-dir="src/com/microsoft/azure/mobile/cordova" />
+        <source-file src="src/android/AppCenterSharedPlugin.java" target-dir="src/com/microsoft/azure/mobile/cordova" />
 
-         <config-file target="res/xml/config.xml" parent="/*">
+        <config-file target="res/xml/config.xml" parent="/*">
             <feature name="AppCenterShared">
                 <param name="onload" value="true" />
-                <param name="android-package"
-                       value="com.microsoft.azure.mobile.cordova.AppCenterSharedPlugin"/>
+                <param name="android-package" value="com.microsoft.azure.mobile.cordova.AppCenterSharedPlugin"/>
             </feature>
         </config-file>
         <framework src="com.microsoft.appcenter:appcenter:2.1.0" />
@@ -46,7 +48,7 @@
     <platform name="ios">
         <header-file src="src/ios/AppCenterShared.h" />
         <source-file src="src/ios/AppCenterShared.m" />
-          <config-file target="config.xml" parent="/*">
+        <config-file target="config.xml" parent="/*">
             <feature name="AppCenterShared">
                 <param name="ios-package" value="AppCenterSharedPlugin" />
                 <param name="onload" value="true" />
@@ -55,6 +57,16 @@
 
         <header-file src="src/ios/AppCenterSharedPlugin.h" />
         <source-file src="src/ios/AppCenterSharedPlugin.m" />
+        <podspec>
+            <config>
+                <source url="https://github.com/CocoaPods/Specs.git"/>
+            </config>
+            <pods use-frameworks="true">
+                <pod name="AppCenter" spec="~> 2.1.0" />
+            </pods>
+        </podspec>
+
         <framework src="AppCenter" type="podspec" spec="~> 2.1.0" />
     </platform>
 </plugin>
+

--- a/cordova-plugin-appcenter-shared/plugin.xml
+++ b/cordova-plugin-appcenter-shared/plugin.xml
@@ -1,14 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<<<<<<< Updated upstream
 <plugin id="cordova-plugin-appcenter-shared"
         version="0.3.5"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
-=======
-<plugin id="cordova-plugin-appcenter-shared" version="0.3.4" 
-    xmlns="http://apache.org/cordova/ns/plugins/1.0" 
-    xmlns:android="http://schemas.android.com/apk/res/android">
->>>>>>> Stashed changes
 
     <name>App Center shared code for Cordova</name>
     <description>

--- a/cordova-plugin-appcenter-shared/plugin.xml
+++ b/cordova-plugin-appcenter-shared/plugin.xml
@@ -18,22 +18,26 @@
     <!-- Cordova 6.4.0 and iOS 4.3.0 are required for Cocoapods support -->
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
-
+    
     <js-module name="AppCenter" src="www/AppCenter.js">
         <clobbers target="AppCenter" />
     </js-module>
 
     <platform name="android">
-        <source-file src="src/android/AppCenterShared.java" target-dir="src/com/microsoft/azure/mobile/cordova" />
+        <source-file src="src/android/AppCenterShared.java"
+                     target-dir="src/com/microsoft/azure/mobile/cordova" />
 
-        <source-file src="src/android/AppCenterUtils.java" target-dir="src/com/microsoft/azure/mobile/cordova" />
+        <source-file src="src/android/AppCenterUtils.java"
+                     target-dir="src/com/microsoft/azure/mobile/cordova" />
 
-        <source-file src="src/android/AppCenterSharedPlugin.java" target-dir="src/com/microsoft/azure/mobile/cordova" />
+        <source-file src="src/android/AppCenterSharedPlugin.java"
+                target-dir="src/com/microsoft/azure/mobile/cordova" />
 
-        <config-file target="res/xml/config.xml" parent="/*">
+         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="AppCenterShared">
                 <param name="onload" value="true" />
-                <param name="android-package" value="com.microsoft.azure.mobile.cordova.AppCenterSharedPlugin"/>
+                <param name="android-package"
+                       value="com.microsoft.azure.mobile.cordova.AppCenterSharedPlugin"/>
             </feature>
         </config-file>
         <framework src="com.microsoft.appcenter:appcenter:2.1.0" />
@@ -42,7 +46,7 @@
     <platform name="ios">
         <header-file src="src/ios/AppCenterShared.h" />
         <source-file src="src/ios/AppCenterShared.m" />
-        <config-file target="config.xml" parent="/*">
+          <config-file target="config.xml" parent="/*">
             <feature name="AppCenterShared">
                 <param name="ios-package" value="AppCenterSharedPlugin" />
                 <param name="onload" value="true" />
@@ -59,7 +63,6 @@
                 <pod name="AppCenter" spec="~> 2.1.0" />
             </pods>
         </podspec>
-
         <framework src="AppCenter" type="podspec" spec="~> 2.1.0" />
     </platform>
 </plugin>


### PR DESCRIPTION
[AB#61229](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/61229)
Had some troubles there but finally it works (got [help](https://github.com/apache/cordova-ios/issues/621) from cordova community). 
Also, the new tag won't work on the CLI < `9.0.0` so I kept the legacy `framework ` tag as a fallback for now.