### PR TITLE
Release 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.3.6
+
+- Updated App Center dependencies
+- **[Bugfix]**: Removed deprecated framework tags
+___
+
 ## Version 0.3.5
 
 - **[Bugfix]**: Fixed PushListener not being called from background

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Version 0.3.6
 
-- Updated App Center dependencies
 - **[Bugfix]**: Removed deprecated framework tags
+Updated native SDK versions:
+- Android from `2.1.0` to [2.2.0](https://github.com/Microsoft/AppCenter-SDK-Android/releases/tag/2.2.0)
+- iOS from `2.1.0` to [2.2.0](https://github.com/Microsoft/AppCenter-SDK-Apple/releases/tag/2.2.0)
+
 ___
 
 ## Version 0.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Version 0.3.6
 
+Changes:
 - **[Bugfix]**: Removed deprecated framework tags
+
 Updated native SDK versions:
 - Android from `2.1.0` to [2.2.0](https://github.com/Microsoft/AppCenter-SDK-Android/releases/tag/2.2.0)
 - iOS from `2.1.0` to [2.2.0](https://github.com/Microsoft/AppCenter-SDK-Apple/releases/tag/2.2.0)
-
 ___
 
 ## Version 0.3.5

--- a/cordova-plugin-appcenter-analytics/package.json
+++ b/cordova-plugin-appcenter-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-analytics",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Provides Microsoft Azure App Center Analytics client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-analytics"
-        version="0.3.5"
+        version="0.3.6"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -19,7 +19,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.3.5"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.3.6"/>
 
     <js-module name="Analytics" src="www/Analytics.js">
         <clobbers target="AppCenter.Analytics" />
@@ -39,7 +39,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-analytics:2.1.0" />
+        <framework src="com.microsoft.appcenter:appcenter-analytics:2.2.0" />
 
         <source-file src="src/android/AppCenterAnalyticsPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />
@@ -65,9 +65,9 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Analytics" spec="~> 2.1.0" />
+                <pod name="AppCenter/Analytics" spec="~> 2.2.0" />
             </pods>
         </podspec>
-        <framework src="AppCenter" type="podspec" spec="~> 2.1.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.2.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-crashes/package.json
+++ b/cordova-plugin-appcenter-crashes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-crashes",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Provides Microsoft Azure App Center Crashes client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-crashes"
-        version="0.3.5"
+        version="0.3.6"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -20,7 +20,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.3.5"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.3.6"/>
 
     <js-module name="Crashes" src="www/Crashes.js">
         <clobbers target="AppCenter.Crashes" />
@@ -40,7 +40,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-crashes:2.1.0" />
+        <framework src="com.microsoft.appcenter:appcenter-crashes:2.2.0" />
 
         <source-file src="src/android/AppCenterCrashesPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />
@@ -74,10 +74,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Crashes" spec="~> 2.1.0" />
+                <pod name="AppCenter/Crashes" spec="~> 2.2.0" />
             </pods>
         </podspec>
 
-        <framework src="AppCenter" type="podspec" spec="~> 2.1.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.2.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-push/package.json
+++ b/cordova-plugin-appcenter-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-push",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Provides Microsoft Azure App Center Push client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-push"
-        version="0.3.5"
+        version="0.3.6"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -20,7 +20,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.3.5"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.3.6"/>
 
     <js-module name="Push" src="www/Push.js">
         <clobbers target="AppCenter.Push" />
@@ -40,7 +40,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-push:2.1.0" />
+        <framework src="com.microsoft.appcenter:appcenter-push:2.2.0" />
         <framework src="src/android/AppCenterPush.gradle"
                    custom="true" type="gradleReference" />
 
@@ -90,10 +90,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Push" spec="~> 2.1.0" />
+                <pod name="AppCenter/Push" spec="~> 2.2.0" />
             </pods>
         </podspec>
 
-        <framework src="AppCenter/Push" type="podspec" spec="~> 2.1.0" />
+        <framework src="AppCenter/Push" type="podspec" spec="~> 2.2.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-shared/package.json
+++ b/cordova-plugin-appcenter-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-shared",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Provides Microsoft Azure App Center shared functionality for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-shared/plugin.xml
+++ b/cordova-plugin-appcenter-shared/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-shared"
-        version="0.3.5"
+        version="0.3.6"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -40,7 +40,7 @@
                        value="com.microsoft.azure.mobile.cordova.AppCenterSharedPlugin"/>
             </feature>
         </config-file>
-        <framework src="com.microsoft.appcenter:appcenter:2.1.0" />
+        <framework src="com.microsoft.appcenter:appcenter:2.2.0" />
     </platform>
 
     <platform name="ios">
@@ -60,10 +60,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter" spec="~> 2.1.0" />
+                <pod name="AppCenter" spec="~> 2.2.0" />
             </pods>
         </podspec>
-        <framework src="AppCenter" type="podspec" spec="~> 2.1.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.2.0" />
     </platform>
 </plugin>
 


### PR DESCRIPTION
Changes:
- **[Bugfix]**: Removed deprecated framework tags

Updated native SDK versions:
- Android from `2.1.0` to [2.2.0](https://github.com/Microsoft/AppCenter-SDK-Android/releases/tag/2.2.0)
- iOS from `2.1.0` to [2.2.0](https://github.com/Microsoft/AppCenter-SDK-Apple/releases/tag/2.2.0)