### PR TITLE
Update DemoApp with v. 0.3.6

### DIFF
--- a/demoapp/config.xml
+++ b/demoapp/config.xml
@@ -32,10 +32,10 @@
     <plugin name="cordova-plugin-whitelist" spec="^1.3.3" />
     <plugin name="cordova-plugin-file" spec="^4.0.0" />
     <plugin name="cordova-plugin-camera" spec="^3.0.0" />
-    <plugin name="cordova-plugin-appcenter-analytics" spec="^0.3.5" />
-    <plugin name="cordova-plugin-appcenter-crashes" spec="^0.3.5" />
-    <plugin name="cordova-plugin-appcenter-push" spec="^0.3.5" />
-    <plugin name="cordova-plugin-appcenter-shared" spec="^0.3.5" />
+    <plugin name="cordova-plugin-appcenter-analytics" spec="^0.3.6" />
+    <plugin name="cordova-plugin-appcenter-crashes" spec="^0.3.6" />
+    <plugin name="cordova-plugin-appcenter-push" spec="^0.3.6" />
+    <plugin name="cordova-plugin-appcenter-shared" spec="^0.3.6" />
     <engine name="android" spec="^7.0.0" />
     <engine name="ios" spec="5.0.0" />
 </widget>

--- a/demoapp/config.xml
+++ b/demoapp/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.test.cordovaapp" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.microsoft.appcenter.cordova.demoapp" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>HelloCordova</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.
@@ -19,13 +19,13 @@
     <preference name="APPCENTER_ANALYTICS_ENABLE_IN_JS" value="true" />
     <preference name="APPCENTER_CRASHES_ALWAYS_SEND" value="false" />
     <platform name="android">
-        <preference name="APP_SECRET" value="paste_android_app_secret_here" />
+        <preference name="APP_SECRET" value="adabe47b-4deb-4be2-803b-d8db7eab3530" />
         <resource-file src="google-services.json" target="app/google-services.json" />
         <allow-intent href="market:*" />
     </platform>
     <platform name="ios">
         <preference name="deployment-target" value="9.0" />
-        <preference name="APP_SECRET" value="paste_ios_app_secret_here" />
+        <preference name="APP_SECRET" value="a123b578-dd08-46b1-9590-5a7ca0c3ab0d" />
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
     </platform>

--- a/demoapp/google-services.json
+++ b/demoapp/google-services.json
@@ -1,0 +1,22 @@
+{
+  "project_info": {
+    "project_number": "177539951155",
+    "project_id": "mobile-center-sdk-android"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:177539951155:android:c4c381f689d15fc3",
+        "android_client_info": {
+          "package_name": "com.microsoft.appcenter.cordova.demoapp"
+        }
+      },
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ]
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/demoapp/www/index.html
+++ b/demoapp/www/index.html
@@ -32,7 +32,7 @@
         </div>
 
         <div data-role="footer">
-            <h1>Cordova SDK version 0.3.5</h1>
+            <h1>Cordova SDK version 0.3.6</h1>
         </div>
     </div>
 
@@ -53,7 +53,7 @@
         </div>
 
         <div data-role="footer">
-            <h1>Cordova SDK version 0.3.5</h1>
+            <h1>Cordova SDK version 0.3.6</h1>
         </div>
     </div>
 
@@ -83,7 +83,7 @@
         </div>
 
         <div data-role="footer">
-            <h1>Cordova SDK version 0.3.5</h1>
+            <h1>Cordova SDK version 0.3.6</h1>
         </div>
     </div>
 
@@ -99,7 +99,7 @@
         </div>
 
         <div data-role="footer">
-            <h1>Cordova SDK version 0.3.5</h1>
+            <h1>Cordova SDK version 0.3.6</h1>
         </div>
     </div>
 
@@ -122,7 +122,7 @@
         </div>
 
         <div data-role="footer">
-            <h1>Cordova SDK version 0.3.5</h1>
+            <h1>Cordova SDK version 0.3.6</h1>
         </div>
     </div>
 </body>


### PR DESCRIPTION
This PR bumps versions of used AppCenter SDK to 0.3.6 and updates footers in demoapp to show ver. 0.3.6