### PR TITLE
Bump wrapper sdk version

### DIFF
--- a/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
+++ b/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
@@ -11,7 +11,7 @@ import com.microsoft.appcenter.ingestion.models.WrapperSdk;
 class AppCenterShared {
 
     // TODO: Refine constants
-    private final static String VERSION_NAME = "0.0.1";
+    private final static String VERSION_NAME = "0.3.6";
     private final static String SDK_NAME = "appcenter.cordova";
     private static final String APP_SECRET = "APP_SECRET";
     private static final String LOG_URL = "LOG_URL";

--- a/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
+++ b/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
@@ -39,7 +39,7 @@ static MSWrapperSdk * wrapperSdk;
 
     MSWrapperSdk* wrapperSdk =
     [[MSWrapperSdk alloc]
-     initWithWrapperSdkVersion:@"0.0.1"
+     initWithWrapperSdkVersion:@"0.3.6"
      wrapperSdkName:@"appcenter.cordova"
      wrapperRuntimeVersion:nil
      liveUpdateReleaseLabel:nil


### PR DESCRIPTION
This PR will bump missing version code in both Android and iOS cordova implementation.

[AB#65924](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/65924)