### PR TITLE
Release Cordova 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.4.1
+
+Updated native SDK versions:
+- iOS from `2.3.0` to [2.4.0](https://github.com/microsoft/appcenter-sdk-apple/releases/tag/2.4.0)
+___
+
 ## Version 0.4.0
 
 Changes:

--- a/cordova-plugin-appcenter-analytics/package.json
+++ b/cordova-plugin-appcenter-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-analytics",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Provides Microsoft Azure App Center Analytics client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-analytics"
-        version="0.4.0"
+        version="0.4.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -65,9 +65,9 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Analytics" spec="~> 2.3.0" />
+                <pod name="AppCenter/Analytics" spec="~> 2.4.0" />
             </pods>
         </podspec>
-        <framework src="AppCenter" type="podspec" spec="~> 2.3.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.4.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -19,7 +19,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.4.0"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.4.1"/>
 
     <js-module name="Analytics" src="www/Analytics.js">
         <clobbers target="AppCenter.Analytics" />

--- a/cordova-plugin-appcenter-crashes/package.json
+++ b/cordova-plugin-appcenter-crashes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-crashes",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Provides Microsoft Azure App Center Crashes client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -20,7 +20,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.4.0"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.4.1"/>
 
     <js-module name="Crashes" src="www/Crashes.js">
         <clobbers target="AppCenter.Crashes" />

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-crashes"
-        version="0.4.0"
+        version="0.4.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -74,10 +74,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Crashes" spec="~> 2.3.0" />
+                <pod name="AppCenter/Crashes" spec="~> 2.4.0" />
             </pods>
         </podspec>
 
-        <framework src="AppCenter" type="podspec" spec="~> 2.3.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.4.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-push/package.json
+++ b/cordova-plugin-appcenter-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-push",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Provides Microsoft Azure App Center Push client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-push"
-        version="0.4.0"
+        version="0.4.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -90,10 +90,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Push" spec="~> 2.3.0" />
+                <pod name="AppCenter/Push" spec="~> 2.4.0" />
             </pods>
         </podspec>
 
-        <framework src="AppCenter/Push" type="podspec" spec="~> 2.3.0" />
+        <framework src="AppCenter/Push" type="podspec" spec="~> 2.4.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -20,7 +20,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.4.0"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.4.1"/>
 
     <js-module name="Push" src="www/Push.js">
         <clobbers target="AppCenter.Push" />

--- a/cordova-plugin-appcenter-shared/package.json
+++ b/cordova-plugin-appcenter-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-shared",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Provides Microsoft Azure App Center shared functionality for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-shared/plugin.xml
+++ b/cordova-plugin-appcenter-shared/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-shared"
-        version="0.4.0"
+        version="0.4.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/cordova-plugin-appcenter-shared/plugin.xml
+++ b/cordova-plugin-appcenter-shared/plugin.xml
@@ -60,10 +60,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter" spec="~> 2.3.0" />
+                <pod name="AppCenter" spec="~> 2.4.0" />
             </pods>
         </podspec>
-        <framework src="AppCenter" type="podspec" spec="~> 2.3.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.4.0" />
     </platform>
 </plugin>
 

--- a/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
+++ b/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
@@ -13,7 +13,7 @@ import com.microsoft.appcenter.ingestion.models.WrapperSdk;
 class AppCenterShared {
 
     // TODO: Refine constants
-    private final static String VERSION_NAME = "0.4.0";
+    private final static String VERSION_NAME = "0.4.1";
     private final static String SDK_NAME = "appcenter.cordova";
     private static final String APP_SECRET = "APP_SECRET";
     private static final String LOG_URL = "LOG_URL_KEY";

--- a/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
+++ b/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
@@ -40,7 +40,7 @@ static MSWrapperSdk * wrapperSdk;
 
     MSWrapperSdk* wrapperSdk =
     [[MSWrapperSdk alloc]
-     initWithWrapperSdkVersion:@"0.4.0"
+     initWithWrapperSdkVersion:@"0.4.1"
      wrapperSdkName:@"appcenter.cordova"
      wrapperRuntimeVersion:nil
      liveUpdateReleaseLabel:nil


### PR DESCRIPTION
Updated native SDK versions:
iOS from `2.3.0` to [2.4.0](https://github.com/microsoft/appcenter-sdk-apple/releases/tag/2.4.0)