### PR TITLE
Prepare for stack trace change in android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Version 0.4.2
+
+### App Center Crashes
+
+#### Android
+
+- **[Bug Fix]** Fixes a securituy issue in the way native Android crashes are processed. The exception message will now be `null` and the exception stack trace might look slightly different.
+
+
 ## Version 0.4.1
 
 Updated native SDK versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 0.4.2
+## Version 0.5.0 (Under development)
 
 ### App Center Crashes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Android
 
-- **[Bug Fix]** Fixes a securituy issue in the way native Android crashes are processed. The exception message will now be `null` and the exception stack trace might look slightly different.
+- **[Bug Fix]** Fixes a security issue in the way native Android crashes are processed. The exception message will now be `null` and the exception stack trace might look slightly different.
 
 
 ## Version 0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Android
 
-- **[Behavior change]** Fix a security issue in the way native Android crashes are processed. As a result, the exception stack trace for crashes that occurred in Java code is the raw Java stack trace and the associated exception message is now `null`.
+- **[Behavior change]** Fix a security issue in the way native Android crashes are processed. As a result, the exception stack trace for crashes that occurred in Java code is now the raw Java stack trace and the associated exception message is now `null`.
 
 _
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 #### Android
 
-- **[Bug Fix]** Fixes a security issue in the way native Android crashes are processed. The exception message will now be `null` and the exception stack trace might look slightly different.
+- **[Behavior change]** Fix a security issue in the way native Android crashes are processed. As a result, the exception stack trace for crashes that occurred in Java code is the raw Java stack trace and the associated exception message is now `null`.
 
+_
 
 ## Version 0.4.1
 

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -40,7 +40,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-crashes:2.3.0" />
+        <framework src="src/android/plugin.gradle" custom="true" type="gradleReference"/>
 
         <source-file src="src/android/AppCenterCrashesPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />

--- a/cordova-plugin-appcenter-crashes/src/android/CrashesUtils.java
+++ b/cordova-plugin-appcenter-crashes/src/android/CrashesUtils.java
@@ -44,9 +44,7 @@ class CrashesUtils {
         jsonReport.put("threadName", errorReport.getThreadName());
         jsonReport.put("appErrorTime", "" + errorReport.getAppErrorTime().getTime());
         jsonReport.put("appStartTime", "" + errorReport.getAppStartTime().getTime());
-        jsonReport.put("exception", Log.getStackTraceString(errorReport.getThrowable()));
-        //noinspection ThrowableResultOfMethodCallIgnored
-        jsonReport.put("exceptionReason", errorReport.getThrowable().getMessage());
+        jsonReport.put("exception", errorReport.getStackTrace());
 
         Device deviceInfo = errorReport.getDevice();
         JSONStringer jsonStringer = new JSONStringer();

--- a/cordova-plugin-appcenter-crashes/src/android/plugin.gradle
+++ b/cordova-plugin-appcenter-crashes/src/android/plugin.gradle
@@ -1,0 +1,9 @@
+repositories {
+    maven {
+            url  "https://dl.bintray.com/vsappcenter/appcenter-snapshot"
+    }
+}
+
+dependencies {
+    implementation 'com.microsoft.appcenter:appcenter-crashes:2.4.0-3+08074e47b'
+}

--- a/demoapp/package.json
+++ b/demoapp/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "cordova-android": "^7.1.4",
+    "cordova-ios": "^5.0.0",
     "cordova-plugin-appcenter-analytics": "file:../cordova-plugin-appcenter-analytics",
     "cordova-plugin-appcenter-crashes": "file:../cordova-plugin-appcenter-crashes",
     "cordova-plugin-appcenter-push": "file:../cordova-plugin-appcenter-push",

--- a/demoapp/package.json
+++ b/demoapp/package.json
@@ -19,15 +19,14 @@
     }
   },
   "dependencies": {
-    "cordova-android": "^7.0.0",
-    "cordova-ios": "^5.0.0",
-    "cordova-plugin-appcenter-analytics": "^0.4.1",
-    "cordova-plugin-appcenter-crashes": "^0.4.1",
-    "cordova-plugin-appcenter-push": "^0.4.1",
-    "cordova-plugin-appcenter-shared": "^0.4.1",
+    "cordova-android": "^7.1.4",
+    "cordova-plugin-appcenter-analytics": "file:../cordova-plugin-appcenter-analytics",
+    "cordova-plugin-appcenter-crashes": "file:../cordova-plugin-appcenter-crashes",
+    "cordova-plugin-appcenter-push": "file:../cordova-plugin-appcenter-push",
+    "cordova-plugin-appcenter-shared": "file:../cordova-plugin-appcenter-shared",
     "cordova-plugin-camera": "^3.0.0",
     "cordova-plugin-file": "^5.0.0",
     "cordova-plugin-generate-low-memory": "file:../cordova-plugin-generate-low-memory",
-    "cordova-plugin-whitelist": "^1.3.3"
+    "cordova-plugin-whitelist": "^1.3.4"
   }
 }


### PR DESCRIPTION
Pardon the messy history; accidentally pushed to master the first time. This prepares for the stack trace change in Android. Can't merge until the native SDK is available.