### PR TITLE
Release cordova 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-## Version 0.5.0 (Under development)
+## Version 0.5.0
 
-### App Center Crashes
-
-#### Android
-
+Changes:
 - **[Behavior change]** Fix a security issue in the way native Android crashes are processed. As a result, the exception stack trace for crashes that occurred in Java code is now the raw Java stack trace and the associated exception message is now `null`.
 
+Updated native SDK versions:
+- Android from `2.3.0` to [2.4.0](https://github.com/microsoft/appcenter-sdk-android/releases/tag/2.4.0)
+- iOS from `2.4.0` to [2.5.0](https://github.com/microsoft/appcenter-sdk-apple/releases/tag/2.5.0)
 _
 
 ## Version 0.4.1

--- a/cordova-plugin-appcenter-analytics/package.json
+++ b/cordova-plugin-appcenter-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-analytics",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Provides Microsoft Azure App Center Analytics client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-analytics"
-        version="0.4.1"
+        version="0.5.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -19,7 +19,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.4.1"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.5.0"/>
 
     <js-module name="Analytics" src="www/Analytics.js">
         <clobbers target="AppCenter.Analytics" />
@@ -39,7 +39,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-analytics:2.3.0" />
+        <framework src="com.microsoft.appcenter:appcenter-analytics:2.4.0" />
 
         <source-file src="src/android/AppCenterAnalyticsPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />
@@ -65,9 +65,9 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Analytics" spec="~> 2.4.0" />
+                <pod name="AppCenter/Analytics" spec="~> 2.5.0" />
             </pods>
         </podspec>
-        <framework src="AppCenter" type="podspec" spec="~> 2.4.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.5.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-crashes/package.json
+++ b/cordova-plugin-appcenter-crashes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-crashes",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Provides Microsoft Azure App Center Crashes client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-crashes"
-        version="0.4.1"
+        version="0.5.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -20,7 +20,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.4.1"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.5.0"/>
 
     <js-module name="Crashes" src="www/Crashes.js">
         <clobbers target="AppCenter.Crashes" />
@@ -40,7 +40,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="src/android/plugin.gradle" custom="true" type="gradleReference"/>
+        <framework src="com.microsoft.appcenter:appcenter-crashes:2.4.0" />
 
         <source-file src="src/android/AppCenterCrashesPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />
@@ -74,10 +74,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Crashes" spec="~> 2.4.0" />
+                <pod name="AppCenter/Crashes" spec="~> 2.5.0" />
             </pods>
         </podspec>
 
-        <framework src="AppCenter" type="podspec" spec="~> 2.4.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.5.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-crashes/src/android/plugin.gradle
+++ b/cordova-plugin-appcenter-crashes/src/android/plugin.gradle
@@ -1,9 +1,0 @@
-repositories {
-    maven {
-        url  "https://dl.bintray.com/vsappcenter/appcenter-snapshot"
-    }
-}
-
-dependencies {
-    implementation 'com.microsoft.appcenter:appcenter-crashes:2.4.0-3+08074e47b'
-}

--- a/cordova-plugin-appcenter-push/package.json
+++ b/cordova-plugin-appcenter-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-push",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Provides Microsoft Azure App Center Push client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-push"
-        version="0.4.1"
+        version="0.5.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -20,7 +20,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.4.1"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.5.0"/>
 
     <js-module name="Push" src="www/Push.js">
         <clobbers target="AppCenter.Push" />
@@ -40,7 +40,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-push:2.3.0" />
+        <framework src="com.microsoft.appcenter:appcenter-push:2.4.0" />
         <framework src="src/android/AppCenterPush.gradle"
                    custom="true" type="gradleReference" />
 
@@ -90,10 +90,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter/Push" spec="~> 2.4.0" />
+                <pod name="AppCenter/Push" spec="~> 2.5.0" />
             </pods>
         </podspec>
 
-        <framework src="AppCenter/Push" type="podspec" spec="~> 2.4.0" />
+        <framework src="AppCenter/Push" type="podspec" spec="~> 2.5.0" />
     </platform>
 </plugin>

--- a/cordova-plugin-appcenter-shared/package.json
+++ b/cordova-plugin-appcenter-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-shared",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Provides Microsoft Azure App Center shared functionality for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-shared/plugin.xml
+++ b/cordova-plugin-appcenter-shared/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-shared"
-        version="0.4.1"
+        version="0.5.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -40,7 +40,7 @@
                        value="com.microsoft.azure.mobile.cordova.AppCenterSharedPlugin"/>
             </feature>
         </config-file>
-        <framework src="com.microsoft.appcenter:appcenter:2.3.0" />
+        <framework src="com.microsoft.appcenter:appcenter:2.4.0" />
     </platform>
 
     <platform name="ios">
@@ -60,10 +60,10 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="AppCenter" spec="~> 2.4.0" />
+                <pod name="AppCenter" spec="~> 2.5.0" />
             </pods>
         </podspec>
-        <framework src="AppCenter" type="podspec" spec="~> 2.4.0" />
+        <framework src="AppCenter" type="podspec" spec="~> 2.5.0" />
     </platform>
 </plugin>
 

--- a/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
+++ b/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
@@ -13,7 +13,7 @@ import com.microsoft.appcenter.ingestion.models.WrapperSdk;
 class AppCenterShared {
 
     // TODO: Refine constants
-    private final static String VERSION_NAME = "0.4.1";
+    private final static String VERSION_NAME = "0.5.0";
     private final static String SDK_NAME = "appcenter.cordova";
     private static final String APP_SECRET = "APP_SECRET";
     private static final String LOG_URL = "LOG_URL_KEY";

--- a/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
+++ b/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
@@ -40,7 +40,7 @@ static MSWrapperSdk * wrapperSdk;
 
     MSWrapperSdk* wrapperSdk =
     [[MSWrapperSdk alloc]
-     initWithWrapperSdkVersion:@"0.4.1"
+     initWithWrapperSdkVersion:@"0.5.0"
      wrapperSdkName:@"appcenter.cordova"
      wrapperRuntimeVersion:nil
      liveUpdateReleaseLabel:nil


### PR DESCRIPTION
Changes:
- **[Behavior change]** Fix a security issue in the way native Android crashes are processed. As a result, the exception stack trace for crashes that occurred in Java code is now the raw Java stack trace and the associated exception message is now `null`.

Updated native SDK versions:
- Android from `2.3.0` to [2.4.0](https://github.com/microsoft/appcenter-sdk-android/releases/tag/2.4.0)
- iOS from `2.4.0` to [2.5.0](https://github.com/microsoft/appcenter-sdk-apple/releases/tag/2.5.0)