### PR TITLE
Freeze gradle version to avoid bug in 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.6.0 (under development)
+
+- **[Fix]** Freeze the gradle version to avoid issues introduced by it.
+
 ## Version 0.5.0
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Version 0.6.0 (under development)
 
-- **[Fix]** Freeze the gradle version to avoid issues introduced by it.
+- **[Fix]** Use exact version of the build gradle plugin in the Push module to avoid issues with unstable latest versions.
 
 ## Version 0.5.0
 

--- a/cordova-plugin-appcenter-push/src/android/AppCenterPush.gradle
+++ b/cordova-plugin-appcenter-push/src/android/AppCenterPush.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.+'
         classpath 'com.google.gms:google-services:4.0.1'
     }
 }

--- a/cordova-plugin-appcenter-push/src/android/AppCenterPush.gradle
+++ b/cordova-plugin-appcenter-push/src/android/AppCenterPush.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:+'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.google.gms:google-services:4.0.1'
     }
 }

--- a/cordova-plugin-appcenter-push/src/android/AppCenterPush.gradle
+++ b/cordova-plugin-appcenter-push/src/android/AppCenterPush.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.+'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.google.gms:google-services:4.0.1'
     }
 }


### PR DESCRIPTION
Android Studio 4.0 was released yesterday, and with it came a new Gradle version. This gradle version has an issue requiring a workaround described at the end of this article https://androidstudio.googleblog.com/2019/10/android-studio-40-canary-1-available.html. I propose we lock down the gradle version to avoid issues like this in the future.