### PR TITLE
Release cordova 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-## Version 0.5.1 (under development)
+## Version 0.5.1
 
+Changes:
 - **[Fix]** Use exact version of the build gradle plugin in the Push module to avoid issues with unstable latest versions.
+
+Updated native SDK versions:
+- Android from `2.4.0` to [2.4.1](https://github.com/microsoft/appcenter-sdk-android/releases/tag/2.4.1)
+___
 
 ## Version 0.5.0
 

--- a/cordova-plugin-appcenter-analytics/package.json
+++ b/cordova-plugin-appcenter-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-analytics",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Provides Microsoft Azure App Center Analytics client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-analytics/plugin.xml
+++ b/cordova-plugin-appcenter-analytics/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-analytics"
-        version="0.5.0"
+        version="0.5.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -19,7 +19,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.5.0"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.5.1"/>
 
     <js-module name="Analytics" src="www/Analytics.js">
         <clobbers target="AppCenter.Analytics" />
@@ -39,7 +39,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-analytics:2.4.0" />
+        <framework src="com.microsoft.appcenter:appcenter-analytics:2.4.1" />
 
         <source-file src="src/android/AppCenterAnalyticsPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />

--- a/cordova-plugin-appcenter-crashes/package.json
+++ b/cordova-plugin-appcenter-crashes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-crashes",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Provides Microsoft Azure App Center Crashes client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-crashes/plugin.xml
+++ b/cordova-plugin-appcenter-crashes/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-crashes"
-        version="0.5.0"
+        version="0.5.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -20,7 +20,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.5.0"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.5.1"/>
 
     <js-module name="Crashes" src="www/Crashes.js">
         <clobbers target="AppCenter.Crashes" />
@@ -40,7 +40,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-crashes:2.4.0" />
+        <framework src="com.microsoft.appcenter:appcenter-crashes:2.4.1" />
 
         <source-file src="src/android/AppCenterCrashesPlugin.java"
                      target-dir="src/com/microsoft/azure/mobile/cordova" />

--- a/cordova-plugin-appcenter-push/package.json
+++ b/cordova-plugin-appcenter-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-push",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Provides Microsoft Azure App Center Push client for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-push/plugin.xml
+++ b/cordova-plugin-appcenter-push/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-push"
-        version="0.5.0"
+        version="0.5.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -20,7 +20,7 @@
     <engine name="cordova" version=">=6.4.0" />
     <engine name="cordova-ios" version=">=4.3.0" />
 
-    <dependency id="cordova-plugin-appcenter-shared" version="0.5.0"/>
+    <dependency id="cordova-plugin-appcenter-shared" version="0.5.1"/>
 
     <js-module name="Push" src="www/Push.js">
         <clobbers target="AppCenter.Push" />
@@ -40,7 +40,7 @@
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>
 
-        <framework src="com.microsoft.appcenter:appcenter-push:2.4.0" />
+        <framework src="com.microsoft.appcenter:appcenter-push:2.4.1" />
         <framework src="src/android/AppCenterPush.gradle"
                    custom="true" type="gradleReference" />
 

--- a/cordova-plugin-appcenter-shared/package.json
+++ b/cordova-plugin-appcenter-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appcenter-shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Provides Microsoft Azure App Center shared functionality for Cordova",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/cordova-plugin-appcenter-shared/plugin.xml
+++ b/cordova-plugin-appcenter-shared/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-appcenter-shared"
-        version="0.5.0"
+        version="0.5.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -40,7 +40,7 @@
                        value="com.microsoft.azure.mobile.cordova.AppCenterSharedPlugin"/>
             </feature>
         </config-file>
-        <framework src="com.microsoft.appcenter:appcenter:2.4.0" />
+        <framework src="com.microsoft.appcenter:appcenter:2.4.1" />
     </platform>
 
     <platform name="ios">

--- a/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
+++ b/cordova-plugin-appcenter-shared/src/android/AppCenterShared.java
@@ -13,7 +13,7 @@ import com.microsoft.appcenter.ingestion.models.WrapperSdk;
 class AppCenterShared {
 
     // TODO: Refine constants
-    private final static String VERSION_NAME = "0.5.0";
+    private final static String VERSION_NAME = "0.5.1";
     private final static String SDK_NAME = "appcenter.cordova";
     private static final String APP_SECRET = "APP_SECRET";
     private static final String LOG_URL = "LOG_URL_KEY";

--- a/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
+++ b/cordova-plugin-appcenter-shared/src/ios/AppCenterShared.m
@@ -40,7 +40,7 @@ static MSWrapperSdk * wrapperSdk;
 
     MSWrapperSdk* wrapperSdk =
     [[MSWrapperSdk alloc]
-     initWithWrapperSdkVersion:@"0.5.0"
+     initWithWrapperSdkVersion:@"0.5.1"
      wrapperSdkName:@"appcenter.cordova"
      wrapperRuntimeVersion:nil
      liveUpdateReleaseLabel:nil


### PR DESCRIPTION
Changes:
- **[Fix]** Use exact version of the build gradle plugin in the Push module to avoid issues with unstable latest versions.

Updated native SDK versions:
- Android from `2.4.0` to [2.4.1](https://github.com/microsoft/appcenter-sdk-android/releases/tag/2.4.1)