### PR TITLE
Prepare for OutSystems to allow setting secret from calling code rather than config.xml alone

### DIFF
--- a/cordova-plugin-appcenter-analytics/src/ios/AppCenterAnalyticsPlugin.m
+++ b/cordova-plugin-appcenter-analytics/src/ios/AppCenterAnalyticsPlugin.m
@@ -42,7 +42,9 @@
 
 - (void)setEnabled:(CDVInvokedUrlCommand *)command
 {
-    BOOL shouldEnable = [[command argumentAtIndex:0] boolValue];
+    NSString* secret = [command argumentAtIndex:0 withDefault:nil andClass:[NSString class]];
+    [AppCenterShared setAppSecret:secret];
+    BOOL shouldEnable = [[command argumentAtIndex:1] boolValue];
     [MSAnalytics setEnabled:shouldEnable];
 
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];

--- a/cordova-plugin-appcenter-analytics/types/index.d.ts
+++ b/cordova-plugin-appcenter-analytics/types/index.d.ts
@@ -16,6 +16,7 @@ declare namespace AppCenter {
         ): void;
 
         setEnabled(
+            secret: string,
             enabled: boolean,
             success: () => void,
             error: (error: any) => void

--- a/cordova-plugin-appcenter-analytics/www/Analytics.js
+++ b/cordova-plugin-appcenter-analytics/www/Analytics.js
@@ -13,8 +13,8 @@ module.exports = {
         exec(success, error, "AppCenterAnalytics", "isEnabled", []);
     },
 
-    setEnabled: function(enabled, success, error) {
-        exec(success, error, "AppCenterAnalytics", "setEnabled", [enabled]);
+    setEnabled: function(secret, enabled, success, error) {
+        exec(success, error, "AppCenterAnalytics", "setEnabled", [secret], [enabled]);
     },
 
     /*


### PR DESCRIPTION
## Description

For using this plugin in OutSystems, config.xml is not currently available for supplying app secret. In such case, plugin API will need to be invoked with app secret from calling code. 
Hence, allowing the API to provision for AppSecret be supplied in one method which we are interested in calling.
